### PR TITLE
Convert to string if doesn't supported by json dump

### DIFF
--- a/sanic_json_logging/formatters.py
+++ b/sanic_json_logging/formatters.py
@@ -121,6 +121,10 @@ class JSONFormatter(logging.Formatter):
             exc += self.formatStack(record.stack_info)
         exc = exc.lstrip('\n').replace('\n', '<br>')
 
+        # convert to string if not primitive JSON dump values
+        # https://docs.python.org/3/library/json.html#json.JSONDecoder
+        if type(msg) not in [dict, list, str, int, float, bool, None]:
+            msg = str(msg)
         message = OrderedDict((
             ('timestamp', self.format_timestamp(record.created)),
             ('level', record.levelname),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,20 +51,35 @@ def app():
         await log()
         return response.text('')
 
-    @app.route("/test_get_custom_log", methods=['GET'])
-    async def test_get_custom_log(request):
-        class MyClass:
-            def __str__(self):
-                return "my class"
-        await logger.info(MyClass())
-        return response.text('')
-
     yield app
 
 
 @pytest.fixture
 def test_cli(loop, app, test_client):
     return loop.run_until_complete(test_client(app))
+
+
+@pytest.fixture
+def custom_class_log_app():
+    # Create app
+    app = sanic.Sanic("test_sanic_app")
+
+    logger = logging.getLogger('root')
+
+    @app.route("/test_get", methods=['GET'])
+    async def test_get(request):
+        class MyClass:
+            def __str__(self):
+                return "my class"
+        logger.info(MyClass())
+        return response.text('')
+
+    yield app
+
+
+@pytest.fixture
+def custom_class_log_test_cli(loop, custom_class_log_app, test_client):
+    return loop.run_until_complete(test_client(custom_class_log_app))
 
 
 # For testing alternate context_var

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,14 @@ def app():
         await log()
         return response.text('')
 
+    @app.route("/test_get_custom_log", methods=['GET'])
+    async def test_get_custom_log(request):
+        class MyClass:
+            def __str__(self):
+                return "my class"
+        await logger.info(MyClass())
+        return response.text('')
+
     yield app
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,3 +41,21 @@ async def test_json_access_logging_no_ua(test_cli, logs):
             rec = json.loads(rec)
             assert rec['method'] == 'GET'
             assert rec['user_agent'] is None
+            
+async def test_json_convert_to_string_unknown_class(test_cli, logs):
+    """
+    GET request
+    """
+    formatter = JSONReqFormatter()
+
+    with logs('sanic.access') as caplog:
+        resp = await test_cli.get('/test_get_custom_log')
+        assert resp.status == 200
+
+        for log_record in caplog.records:
+            if log_record.name != 'sanic.access':
+                continue
+
+            rec = formatter.format(log_record)
+            rec = json.loads(rec)
+            assert rec['message'] == 'my class'

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,6 @@
 import json
 
-from sanic_json_logging.formatters import JSONReqFormatter
+from sanic_json_logging.formatters import JSONReqFormatter, JSONFormatter
 
 
 async def test_json_access_logging(test_cli, logs):
@@ -41,19 +41,20 @@ async def test_json_access_logging_no_ua(test_cli, logs):
             rec = json.loads(rec)
             assert rec['method'] == 'GET'
             assert rec['user_agent'] is None
-            
-async def test_json_convert_to_string_unknown_class(test_cli, logs):
+
+
+async def test_json_custom_class_logging(custom_class_log_test_cli, logs):
     """
     GET request
     """
-    formatter = JSONReqFormatter()
+    formatter = JSONFormatter()
 
     with logs('sanic.access') as caplog:
-        resp = await test_cli.get('/test_get_custom_log')
+        resp = await custom_class_log_test_cli.get('/test_get')
         assert resp.status == 200
 
         for log_record in caplog.records:
-            if log_record.name != 'sanic.access':
+            if log_record.name == 'sanic.access':
                 continue
 
             rec = formatter.format(log_record)


### PR DESCRIPTION
Actually this plugin crashes if custom class like that: https://github.com/cwacek/python-jsonschema-objects/pull/194 is logged. This PR fix this with supported json types