### PR TITLE
allow traceback formatting to be overridden

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,70 @@ And if you log to the ``root`` logger, inside a request, it'll look like this.
       "req_id": "795617c7-b514-4ed9-bb63-cc4fcd883c3d"
     }
 
+By default this package logs Exceptions with tracebacks as strings, you might want to render the traceback as JSON aswell. To achieve this simply provide an alternate formatter.
+First install this package with its optional dependencies:
+
+.. code-block:: bash
+
+    pip install sanic-json-logging[extratb]
+
+Then inject another Formatter:
+
+
+.. code-block:: python
+
+        from sanic_json_logging import LOGGING_CONFIG_DEFAULTS as cfg
+
+        cfg["formatters"]["generic"]["class"] = "sanic_json_logging.formatters.JSONTracebackJSONFormatter"
+        setup_json_logging(app, disable_json_access_log=True, config=cfg)
+
+After all your tracebacks are formatted properly as JSON:
+
+.. code-block:: json
+
+  {
+    "timestamp": "2021-08-26T23:19:49.412293Z",
+    "level": "ERROR",
+    "message": "Exception occurred while handling uri: 'http://127.0.0.1:8000/'",
+    "type": "exception",
+    "logger": "sanic.error",
+    "worker": 31915,
+    "filename": "handlers.py",
+    "lineno": 146,
+    "traceback": {
+      "exc_type": "Exception",
+      "exc_msg": "foo",
+      "exc_tb": {
+        "frames": [
+          {
+            "func_name": "handle_request",
+            "lineno": 770,
+            "module_name": "sanic.app",
+            "module_path": "/python3.9/site-packages/sanic/app.py",
+            "lasti": 182,
+            "line": "                    response = await response"
+          },
+          {
+            "func_name": "root",
+            "lineno": 20,
+            "module_name": "api.general",
+            "module_path": "/api/general.py",
+            "lasti": 6,
+            "line": "    raise Exception(\"foo\")"
+          }
+        ]
+      }
+    },
+    "req_id": "f128370f-b949-44e7-bb94-4635bbcad486"
+  }
+
+
 Changelog
 ---------
+
+4.0.1
+=====
+* properly disable access logs
 
 4.0.0
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ sanic-testing = "*"
 pytest-cov = "*"
 mypy = "*"
 
+[tool.poetry.extras]
+extratb = ["boltons"]
+
 [build-system]
 requires = ["poetry>=0.12", "poetry-dynamic-versioning"]
 build-backend = "poetry.masonry.api"

--- a/sanic_json_logging/formatters.py
+++ b/sanic_json_logging/formatters.py
@@ -202,3 +202,10 @@ class JSONReqFormatter(JSONFormatter):
             message["type"] = "ws_access"
 
         return json.dumps(message)
+
+
+class JSONTracebackJSONFormatter(JSONFormatter):
+    def formatStack(self, stack_info: str) -> str:
+        from boltons import tbutils
+
+        return tbutils.ExceptionInfo.from_current().to_dict()

--- a/sanic_json_logging/formatters.py
+++ b/sanic_json_logging/formatters.py
@@ -96,21 +96,7 @@ class JSONFormatter(logging.Formatter):
             msg_type = "log"
 
         # Deal with tracebacks
-        exc = ""
-        if record.exc_info:
-            # Cache the traceback text to avoid converting it multiple times
-            # (it's constant anyway)
-            if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
-        if record.exc_text:
-            if exc[-1:] != "\n":
-                exc += "\n"
-            exc += record.exc_text
-        if record.stack_info:
-            if exc[-1:] != "\n":
-                exc += "\n"
-            exc += self.formatStack(record.stack_info)
-        exc = exc.lstrip("\n").replace("\n", "<br>")
+        exc = self.formatTraceback(record)
 
         # convert to string if not primitive JSON dump values
         # https://docs.python.org/3/library/json.html#json.JSONDecoder
@@ -152,6 +138,24 @@ class JSONFormatter(logging.Formatter):
 
         # TODO log an error if json.dumps fails
         return json.dumps(message)
+
+    def formatTraceback(self, record):
+        exc = ""
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if exc[-1:] != "\n":
+                exc += "\n"
+            exc += record.exc_text
+        if record.stack_info:
+            if exc[-1:] != "\n":
+                exc += "\n"
+            exc += self.formatStack(record.stack_info)
+        exc = exc.lstrip("\n").replace("\n", "<br>")
+        return exc
 
 
 class JSONReqFormatter(JSONFormatter):


### PR DESCRIPTION
i used it to implement a formatter that formats the traceback as json as well. i was not sure if you liked the additional external library (https://boltons.readthedocs.io/en/latest/tbutils.html#boltons.tbutils.ExceptionInfo.to_dict) so i made it optional and only an idea on how to improve the json format 🙂

```python
from boltons import tbutils
from sanic_json_logging.formatters import JSONFormatter


class JsonTbJSONFormatter(JSONFormatter):
    def formatStack(self, stack_info: str) -> str:
        return tbutils.ExceptionInfo.from_current().to_dict()
```

i combination with #133 it would be like this:

```python
        from sanic_json_logging import LOGGING_CONFIG_DEFAULTS

        cfg = {**LOGGING_CONFIG_DEFAULTS}
        cfg["formatters"]["generic"]["class"] = "JsonTbJSONFormatter"

        setup_json_logging(app, disable_json_access_log=True, config=cfg)
```

in the end you get a nice exception traceback:

```json
{
  "timestamp": "2021-08-26T23:19:49.412293Z",
  "level": "ERROR",
  "message": "Exception occurred while handling uri: 'http://127.0.0.1:8000/'",
  "type": "exception",
  "logger": "sanic.error",
  "worker": 31915,
  "filename": "handlers.py",
  "lineno": 146,
  "traceback": {
    "exc_type": "Exception",
    "exc_msg": "foo",
    "exc_tb": {
      "frames": [
        {
          "func_name": "handle_request",
          "lineno": 770,
          "module_name": "sanic.app",
          "module_path": "/usr/local/lib/python3.9/site-packages/sanic/app.py",
          "lasti": 182,
          "line": "                    response = await response"
        },
        {
          "func_name": "root",
          "lineno": 20,
          "module_name": "api.general",
          "module_path": "/api/controllers/general.py",
          "lasti": 6,
          "line": "    raise Exception(\"foo\")"
        }
      ]
    }
  },
  "req_id": "f128370f-b949-44e7-bb94-4635bbcad486"
}
```