### PR TITLE
fix formatter when exception is missing

### DIFF
--- a/sanic_json_logging/formatters.py
+++ b/sanic_json_logging/formatters.py
@@ -209,7 +209,7 @@ class JSONTracebackJSONFormatter(JSONFormatter):
     def formatTraceback(self, record: logging.LogRecord) -> Optional[str]:
         from boltons import tbutils
 
-        if not hasattr(record, "exc_info") or (record.exc_info and len(record.exc_info) < 3):
+        if not hasattr(record, "exc_info") or record.exc_info is None or (record.exc_info and len(record.exc_info) < 3):
             return None
 
         return tbutils.ExceptionInfo.from_exc_info(*record.exc_info).to_dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,8 +86,19 @@ def json_tb_app():
     setup_json_logging(app, config=cfg)
 
     @app.route("/test_exception", methods=["GET"])
-    async def test_get(request):
+    async def test_exception(request):
         raise Exception("foo")
+        return response.text("")
+
+    @app.route("/test_get", methods=["GET"])
+    async def test_get(request):
+        logger = logging.getLogger("sanic.info")
+
+        class MyClass:
+            def __str__(self):
+                return "my class"
+
+        logger.info(MyClass())
         return response.text("")
 
     return app

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -101,3 +101,16 @@ async def test_json_traceback_error_logging(json_tb_app, logs):
                 assert rec["traceback"]
                 assert rec["type"] == "exception"
                 assert rec["traceback"]["exc_msg"] == "foo"
+
+    with logs("sanic.info") as caplog:
+        _, resp = await json_tb_app.asgi_client.get("/test_get")
+        assert resp.status == 200
+
+        # We should get no access logging
+        for log_record in caplog.records:
+            if log_record.name == "sanic.info":
+                rec = formatter.format(log_record)
+                rec = json.loads(rec)
+                # Check log record has data passed from access logging middleware
+                assert not hasattr(rec, "traceback")
+                assert rec["type"] == "log"


### PR DESCRIPTION
sorry, it seems we missed a case, tested it again in a real world application